### PR TITLE
(ECOMM-39) feat/ add linting rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,47 +1,82 @@
 // @ts-check
-const eslint = require("@eslint/js");
-const tseslint = require("typescript-eslint");
-const angular = require("angular-eslint");
+const eslint = require('@eslint/js');
+const tseslint = require('typescript-eslint');
+const angular = require('angular-eslint');
 const eslintPluginPrettierRecommended = require('eslint-plugin-prettier/recommended');
 
 module.exports = tseslint.config(
   {
-    files: ["**/*.ts"],
+    files: ['**/*.ts'],
     extends: [
       eslint.configs.recommended,
       ...tseslint.configs.recommended,
       ...tseslint.configs.stylistic,
       ...angular.configs.tsRecommended,
-      eslintPluginPrettierRecommended
+      eslintPluginPrettierRecommended,
     ],
     processor: angular.processInlineTemplates,
     rules: {
-      "@angular-eslint/directive-selector": [
-        "error",
+      '@angular-eslint/directive-selector': [
+        'error',
         {
-          type: "attribute",
-          prefix: "app",
-          style: "camelCase",
+          type: 'attribute',
+          prefix: 'app',
+          style: 'camelCase',
         },
       ],
-      "@angular-eslint/component-selector": [
-        "error",
+      '@angular-eslint/component-selector': [
+        'error',
         {
-          type: "element",
-          prefix: "app",
-          style: "kebab-case",
+          type: 'element',
+          prefix: 'app',
+          style: 'kebab-case',
         },
       ],
     },
   },
   {
-    files: ["**/*.html"],
-    extends: [
-      ...angular.configs.templateRecommended,
-      ...angular.configs.templateAccessibility,
-    ],
-    rules: {},
-  },
+    files: ['**/*.html'],
+    extends: [...angular.configs.templateRecommended, ...angular.configs.templateAccessibility],
+    rules: {
+      '@angular-eslint/template/banana-in-box': 'error',
+      '@angular-eslint/template/no-negated-async': 'error',
+      '@angular-eslint/template/cyclomatic-complexity': ['error', 5],
+
+      '@angular-eslint/template/accessibility-alt-text': 'error',
+      '@angular-eslint/template/accessibility-table-scope': 'error',
+      '@angular-eslint/template/no-positive-tabindex': 'error',
+
+      '@angular-eslint/template/use-track-by-function': 'error',
+      '@angular-eslint/template/no-call-expression': 'error',
+
+      '@angular-eslint/template/no-duplicate-attributes': 'error',
+      '@angular-eslint/template/no-inline-styles': 'error',
+
+      '@angular-eslint/prefer-on-push-component-change-detection': 'error',
+
+      '@typescript-eslint/explicit-member-accessibility': [
+        'error',
+        {
+          accessibility: 'explicit',
+          overrides: {
+            конструкторы: 'no-public',
+          },
+        },
+      ],
+      '@typescript-eslint/no-unused-vars': 'error',
+      'unused-imports/no-unused-imports': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'error',
+      'no-commented-out-code': 'error',
+      'no-magic-numbers': [
+        'error',
+        {
+          ignore: [-1, 0, 1],
+          ignoreArrayIndexes: true,
+        },
+      ],
+    },
+  }
+
   // {
   //   files: ["*.html"],
   //   excludedFiles: ["*inline-template-*.component.html"],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ const eslint = require('@eslint/js');
 const tseslint = require('typescript-eslint');
 const angular = require('angular-eslint');
 const eslintPluginPrettierRecommended = require('eslint-plugin-prettier/recommended');
+const noComments = require('eslint-plugin-no-commented-code');
 
 module.exports = tseslint.config(
   {
@@ -14,6 +15,8 @@ module.exports = tseslint.config(
       ...angular.configs.tsRecommended,
       eslintPluginPrettierRecommended,
     ],
+    plugins: { 'no-comments': noComments },
+
     processor: angular.processInlineTemplates,
     rules: {
       '@angular-eslint/directive-selector': [
@@ -32,6 +35,25 @@ module.exports = tseslint.config(
           style: 'kebab-case',
         },
       ],
+      '@typescript-eslint/explicit-member-accessibility': [
+        'error',
+        {
+          accessibility: 'explicit',
+          overrides: {
+            constructors: 'no-public',
+          },
+        },
+      ],
+      '@typescript-eslint/no-unused-vars': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'error',
+      'no-magic-numbers': [
+        'error',
+        {
+          ignore: [-1, 0, 1],
+          ignoreArrayIndexes: true,
+        },
+      ],
+      'no-comments/no-commented-code': 'warn',
     },
   },
   {
@@ -40,40 +62,11 @@ module.exports = tseslint.config(
     rules: {
       '@angular-eslint/template/banana-in-box': 'error',
       '@angular-eslint/template/no-negated-async': 'error',
-      '@angular-eslint/template/cyclomatic-complexity': ['error', 5],
-
-      '@angular-eslint/template/accessibility-alt-text': 'error',
-      '@angular-eslint/template/accessibility-table-scope': 'error',
       '@angular-eslint/template/no-positive-tabindex': 'error',
-
       '@angular-eslint/template/use-track-by-function': 'error',
       '@angular-eslint/template/no-call-expression': 'error',
-
       '@angular-eslint/template/no-duplicate-attributes': 'error',
-      '@angular-eslint/template/no-inline-styles': 'error',
-
-      '@angular-eslint/prefer-on-push-component-change-detection': 'error',
-
-      '@typescript-eslint/explicit-member-accessibility': [
-        'error',
-        {
-          accessibility: 'explicit',
-          overrides: {
-            конструкторы: 'no-public',
-          },
-        },
-      ],
-      '@typescript-eslint/no-unused-vars': 'error',
-      'unused-imports/no-unused-imports': 'error',
-      '@typescript-eslint/explicit-function-return-type': 'error',
-      'no-commented-out-code': 'error',
-      'no-magic-numbers': [
-        'error',
-        {
-          ignore: [-1, 0, 1],
-          ignoreArrayIndexes: true,
-        },
-      ],
+      '@angular-eslint/template/no-inline-styles': 'warn',
     },
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "commitlint": "^19.8.0",
         "eslint": "^9.23.0",
         "eslint-config-prettier": "^10.1.2",
+        "eslint-plugin-no-commented-code": "^1.0.10",
         "eslint-plugin-prettier": "^5.2.6",
         "eslint-plugin-unused-imports": "^4.1.4",
         "husky": "^9.1.7",
@@ -9290,6 +9291,13 @@
       "peerDependencies": {
         "eslint": ">=7.0.0"
       }
+    },
+    "node_modules/eslint-plugin-no-commented-code": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-commented-code/-/eslint-plugin-no-commented-code-1.0.10.tgz",
+      "integrity": "sha512-F8tBlF1WUdivVE9+KoDY4CTIO5kP4Gb4rRBp9UxAxcuemhwMXdT5bpvox7hBVL15SlxeVgloPSXh6QBufIxb2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint-plugin-prettier": {
       "version": "5.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,9 @@
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^19.2.9",
+        "@angular-eslint/eslint-plugin": "^19.4.0",
+        "@angular-eslint/eslint-plugin-template": "^19.4.0",
+        "@angular-eslint/template-parser": "^19.4.0",
         "@angular/cli": "^19.2.9",
         "@angular/compiler-cli": "^19.2.0",
         "@commitlint/cli": "^19.8.0",
@@ -35,6 +38,7 @@
         "eslint": "^9.23.0",
         "eslint-config-prettier": "^10.1.2",
         "eslint-plugin-prettier": "^5.2.6",
+        "eslint-plugin-unused-imports": "^4.1.4",
         "husky": "^9.1.7",
         "jasmine-core": "~5.6.0",
         "karma": "~6.4.0",
@@ -344,14 +348,14 @@
       "license": "MIT"
     },
     "node_modules/@angular-eslint/eslint-plugin": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-19.3.0.tgz",
-      "integrity": "sha512-nBLslLI20KnVbqlfNW7GcnI9R6cYCvRGjOE2QYhzxM316ciAQ62tvQuXP9ZVnRBLSKDAVnMeC0eTq9O4ysrxrQ==",
+      "version": "19.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-19.4.0.tgz",
+      "integrity": "sha512-jXhyYYIdo5ItCFfmw7W5EqDRQx8rYtiYbpezI84CemKPHB/VPiP/zqLIvdTVBdJdXlqS31ueXn2YlWU0w6AAgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "19.3.0",
-        "@angular-eslint/utils": "19.3.0"
+        "@angular-eslint/bundled-angular-compiler": "19.4.0",
+        "@angular-eslint/utils": "19.4.0"
       },
       "peerDependencies": {
         "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
@@ -360,19 +364,63 @@
       }
     },
     "node_modules/@angular-eslint/eslint-plugin-template": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-19.3.0.tgz",
-      "integrity": "sha512-WyouppTpOYut+wvv13wlqqZ8EHoDrCZxNfGKuEUYK1BPmQlTB8EIZfQH4iR1rFVS28Rw+XRIiXo1x3oC0SOfnA==",
+      "version": "19.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-19.4.0.tgz",
+      "integrity": "sha512-6WAGnHf5SKi7k8/AOOLwGCoN3iQUE8caKsg0OucL4CWPUyzsYpQjx7ALKyxx9lqoAngn3CTlQ2tcwDv6aYtfmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "19.3.0",
-        "@angular-eslint/utils": "19.3.0",
+        "@angular-eslint/bundled-angular-compiler": "19.4.0",
+        "@angular-eslint/utils": "19.4.0",
         "aria-query": "5.3.2",
         "axobject-query": "4.1.0"
       },
       "peerDependencies": {
         "@typescript-eslint/types": "^7.11.0 || ^8.0.0",
+        "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@angular-eslint/eslint-plugin-template/node_modules/@angular-eslint/bundled-angular-compiler": {
+      "version": "19.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-19.4.0.tgz",
+      "integrity": "sha512-Djq+je34czagDxvkBbbe1dLlhUGYK2MbHjEgPTQ00tVkacLQGAW4UmT1A0JGZzfzl/lDVvli64/lYQsJTSSM6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@angular-eslint/eslint-plugin-template/node_modules/@angular-eslint/utils": {
+      "version": "19.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-19.4.0.tgz",
+      "integrity": "sha512-2hZ7rf/0YBkn1Rk0i7AlYGlfxQ7+DqEXUsgp1M56mf0cy7/GCFiWZE0lcXFY4kzb4yQK3G2g+kIF092MwelT7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "19.4.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@angular-eslint/eslint-plugin/node_modules/@angular-eslint/bundled-angular-compiler": {
+      "version": "19.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-19.4.0.tgz",
+      "integrity": "sha512-Djq+je34czagDxvkBbbe1dLlhUGYK2MbHjEgPTQ00tVkacLQGAW4UmT1A0JGZzfzl/lDVvli64/lYQsJTSSM6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@angular-eslint/eslint-plugin/node_modules/@angular-eslint/utils": {
+      "version": "19.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-19.4.0.tgz",
+      "integrity": "sha512-2hZ7rf/0YBkn1Rk0i7AlYGlfxQ7+DqEXUsgp1M56mf0cy7/GCFiWZE0lcXFY4kzb4yQK3G2g+kIF092MwelT7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "19.4.0"
+      },
+      "peerDependencies": {
         "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": "*"
@@ -394,20 +442,62 @@
         "strip-json-comments": "3.1.1"
       }
     },
-    "node_modules/@angular-eslint/template-parser": {
+    "node_modules/@angular-eslint/schematics/node_modules/@angular-eslint/eslint-plugin": {
       "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-19.3.0.tgz",
-      "integrity": "sha512-VxMNgsHXMWbbmZeBuBX5i8pzsSSEaoACVpaE+j8Muk60Am4Mxc0PytJm4n3znBSvI3B7Kq2+vStSRYPkOER4lA==",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-19.3.0.tgz",
+      "integrity": "sha512-nBLslLI20KnVbqlfNW7GcnI9R6cYCvRGjOE2QYhzxM316ciAQ62tvQuXP9ZVnRBLSKDAVnMeC0eTq9O4ysrxrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "19.3.0",
+        "@angular-eslint/utils": "19.3.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@angular-eslint/schematics/node_modules/@angular-eslint/eslint-plugin-template": {
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-19.3.0.tgz",
+      "integrity": "sha512-WyouppTpOYut+wvv13wlqqZ8EHoDrCZxNfGKuEUYK1BPmQlTB8EIZfQH4iR1rFVS28Rw+XRIiXo1x3oC0SOfnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "19.3.0",
+        "@angular-eslint/utils": "19.3.0",
+        "aria-query": "5.3.2",
+        "axobject-query": "4.1.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^7.11.0 || ^8.0.0",
+        "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@angular-eslint/template-parser": {
+      "version": "19.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-19.4.0.tgz",
+      "integrity": "sha512-f4t7Z6zo8owOTUqAtZ3G/cMA5hfT3RE2OKR0dLn7YI6LxUJkrlcHq75n60UHiapl5sais6heo70hvjQgJ3fDxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "19.4.0",
         "eslint-scope": "^8.0.2"
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": "*"
       }
+    },
+    "node_modules/@angular-eslint/template-parser/node_modules/@angular-eslint/bundled-angular-compiler": {
+      "version": "19.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-19.4.0.tgz",
+      "integrity": "sha512-Djq+je34czagDxvkBbbe1dLlhUGYK2MbHjEgPTQ00tVkacLQGAW4UmT1A0JGZzfzl/lDVvli64/lYQsJTSSM6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@angular-eslint/template-parser/node_modules/eslint-scope": {
       "version": "8.3.0",
@@ -6975,6 +7065,83 @@
         "typescript-eslint": "^8.0.0"
       }
     },
+    "node_modules/angular-eslint/node_modules/@angular-eslint/eslint-plugin": {
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-19.3.0.tgz",
+      "integrity": "sha512-nBLslLI20KnVbqlfNW7GcnI9R6cYCvRGjOE2QYhzxM316ciAQ62tvQuXP9ZVnRBLSKDAVnMeC0eTq9O4ysrxrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "19.3.0",
+        "@angular-eslint/utils": "19.3.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/angular-eslint/node_modules/@angular-eslint/eslint-plugin-template": {
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-19.3.0.tgz",
+      "integrity": "sha512-WyouppTpOYut+wvv13wlqqZ8EHoDrCZxNfGKuEUYK1BPmQlTB8EIZfQH4iR1rFVS28Rw+XRIiXo1x3oC0SOfnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "19.3.0",
+        "@angular-eslint/utils": "19.3.0",
+        "aria-query": "5.3.2",
+        "axobject-query": "4.1.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^7.11.0 || ^8.0.0",
+        "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/angular-eslint/node_modules/@angular-eslint/template-parser": {
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-19.3.0.tgz",
+      "integrity": "sha512-VxMNgsHXMWbbmZeBuBX5i8pzsSSEaoACVpaE+j8Muk60Am4Mxc0PytJm4n3znBSvI3B7Kq2+vStSRYPkOER4lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "19.3.0",
+        "eslint-scope": "^8.0.2"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/angular-eslint/node_modules/eslint-scope": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/angular-eslint/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -9151,6 +9318,22 @@
           "optional": true
         },
         "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.1.4.tgz",
+      "integrity": "sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "lint": "ng lint",
+    "lint": "ng lint --fix",
     "format": "prettier **/src/* -l -u",
     "prepare": "husky"
   },
@@ -42,6 +42,7 @@
     "commitlint": "^19.8.0",
     "eslint": "^9.23.0",
     "eslint-config-prettier": "^10.1.2",
+    "eslint-plugin-no-commented-code": "^1.0.10",
     "eslint-plugin-prettier": "^5.2.6",
     "eslint-plugin-unused-imports": "^4.1.4",
     "husky": "^9.1.7",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^19.2.9",
+    "@angular-eslint/eslint-plugin": "^19.4.0",
+    "@angular-eslint/eslint-plugin-template": "^19.4.0",
+    "@angular-eslint/template-parser": "^19.4.0",
     "@angular/cli": "^19.2.9",
     "@angular/compiler-cli": "^19.2.0",
     "@commitlint/cli": "^19.8.0",
@@ -40,6 +43,7 @@
     "eslint": "^9.23.0",
     "eslint-config-prettier": "^10.1.2",
     "eslint-plugin-prettier": "^5.2.6",
+    "eslint-plugin-unused-imports": "^4.1.4",
     "husky": "^9.1.7",
     "jasmine-core": "~5.6.0",
     "karma": "~6.4.0",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -8,7 +8,6 @@ describe('AppComponent', () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
       providers: [provideRouter([]), provideHttpClient()],
-
     }).compileComponents();
   });
 
@@ -30,5 +29,4 @@ describe('AppComponent', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled).toBeTruthy();
   });
-
 });

--- a/src/interceptors/api.interceptor.ts
+++ b/src/interceptors/api.interceptor.ts
@@ -5,6 +5,8 @@ import { inject } from '@angular/core';
 import { ApiService } from '../services/api.service';
 import { Router } from '@angular/router';
 
+const INVALID_TOKEN_ERROR = 401;
+
 export function intercept(req: HttpRequest<unknown>, next: HttpHandlerFn): Observable<HttpEvent<unknown>> {
   // Intercept and handle request
   const api = inject(ApiService);
@@ -41,7 +43,7 @@ export function intercept(req: HttpRequest<unknown>, next: HttpHandlerFn): Obser
       },
       error: (err: HttpErrorResponse) => {
         console.error('Error Intercepted:', err);
-        if (err.status === 401) {
+        if (err.status === INVALID_TOKEN_ERROR) {
           // Handle unauthorized access
           // Redirect to login page
           router.navigate(['/login']);

--- a/src/pages/register/register.component.html
+++ b/src/pages/register/register.component.html
@@ -16,7 +16,7 @@
       <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">
         <input matInput formControlName="lastName" placeholder="Enter last name" />
         <mat-error *ngIf="lastName?.hasError('required')">Last name is required.</mat-error>
-        <mat-error *ngIf="firstName?.hasError('pattern')">Letters only, it is quantity one or more.</mat-error>
+        <mat-error *ngIf="lastName?.hasError('pattern')">Letters only, it is quantity one or more.</mat-error>
       </mat-form-field>
       <p class="login-form__label">Enter Your Birth day</p>
       <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">

--- a/src/pages/register/register.component.html
+++ b/src/pages/register/register.component.html
@@ -6,33 +6,34 @@
         Do you have an account?
         <a class="login-form__register-link" routerLink="/login" ariaCurrentWhenActive="page">Login</a>
       </div>
+
       <p class="login-form__label">Enter Your First name</p>
       <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">
         <input matInput formControlName="firstName" placeholder="Enter first name" />
-        <mat-error *ngIf="firstName?.hasError('required')">First name is required.</mat-error>
-        <mat-error *ngIf="firstName?.hasError('pattern')">Letters only, it is quantity one or more.</mat-error>
+        <mat-error *ngIf="firstNameRequiredError">First name is required.</mat-error>
+        <mat-error *ngIf="firstNamePatternError">Letters only, it is quantity one or more.</mat-error>
       </mat-form-field>
+
       <p class="login-form__label">Enter Your Last name</p>
       <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">
         <input matInput formControlName="lastName" placeholder="Enter last name" />
-        <mat-error *ngIf="lastName?.hasError('required')">Last name is required.</mat-error>
-        <mat-error *ngIf="lastName?.hasError('pattern')">Letters only, it is quantity one or more.</mat-error>
+        <mat-error *ngIf="lastNameRequiredError">Last name is required.</mat-error>
+        <mat-error *ngIf="lastNamePatternError">Letters only, it is quantity one or more.</mat-error>
       </mat-form-field>
+
       <p class="login-form__label">Enter Your Birth day</p>
       <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">
         <input
           matInput
           formControlName="dateOfBirth"
           type="date"
-          id="exampleInput"
-          name="input"
-          ng-model="example.value"
           placeholder="yyyy-MM-dd"
           min="1990-01-01"
           max="2025-12-31" />
-        <mat-error *ngIf="dateOfBirth?.hasError('required')">Day of birth is required.</mat-error>
-        <mat-error *ngIf="dateOfBirth?.hasError('minAge')">You must be over 13 years old.</mat-error>
+        <mat-error *ngIf="dateOfBirthRequiredError">Day of birth is required.</mat-error>
+        <mat-error *ngIf="dateOfBirthMinAgeError">You must be over 13 years old.</mat-error>
       </mat-form-field>
+
       <p class="login-form__label">Enter Your Address</p>
       <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">
         <mat-select matInput formControlName="country">
@@ -40,31 +41,37 @@
             <mat-option [value]="data.code">{{ data.name }}</mat-option>
           }
         </mat-select>
-        <mat-error *ngIf="country?.hasError('required')">Country is required.</mat-error>
+        <mat-error *ngIf="countryRequiredError">Country is required.</mat-error>
       </mat-form-field>
+
       <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">
         <input matInput formControlName="city" placeholder="Enter city" />
-        <mat-error *ngIf="city?.hasError('required')">City is required.</mat-error>
-        <mat-error *ngIf="city?.hasError('pattern')">Must contain only letters.</mat-error>
+        <mat-error *ngIf="cityRequiredError">City is required.</mat-error>
+        <mat-error *ngIf="cityPatternError">Must contain only letters.</mat-error>
       </mat-form-field>
+
       <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">
         <input matInput formControlName="street" placeholder="Enter street" />
-        <mat-error *ngIf="street?.hasError('required')">Street is required.</mat-error>
+        <mat-error *ngIf="streetRequiredError">Street is required.</mat-error>
       </mat-form-field>
+
       <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">
         <input matInput formControlName="postalCode" placeholder="Enter postal code" />
-        <mat-error *ngIf="postalCode?.hasError('required')">Postal code is required.</mat-error>
-        <mat-error *ngIf="postalCode?.hasError('postCodeValid')">Postal code is not valid.</mat-error>
+        <mat-error *ngIf="postalCodeRequiredError">Postal code is required.</mat-error>
+        <mat-error *ngIf="postalCodeValidError">Postal code is not valid.</mat-error>
       </mat-form-field>
-      <mat-checkbox appearance="outline" class="example-margin" formControlName="isDefaultAddress"
-        >Set as default address</mat-checkbox
-      >
-      @if (!registerForm.get('isDefaultAddress')?.value) {
+
+      <mat-checkbox appearance="outline" class="example-margin" formControlName="isDefaultAddress">
+        Set as default address
+      </mat-checkbox>
+
+      @if (!isDefaultAddressValue) {
         <mat-accordion>
           <mat-expansion-panel (opened)="panelOpenState.set(true)" (closed)="panelOpenState.set(false)">
             <mat-expansion-panel-header>
               <mat-panel-title> Set billing and shipping addresses </mat-panel-title>
             </mat-expansion-panel-header>
+
             <div>
               <p class="login-form__label">Enter billing Address</p>
               <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">
@@ -74,21 +81,26 @@
                   }
                 </mat-select>
               </mat-form-field>
+
               <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">
                 <input matInput formControlName="cityBilling" placeholder="Enter city" />
               </mat-form-field>
+
               <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">
                 <input matInput formControlName="streetBilling" placeholder="Enter street" />
               </mat-form-field>
+
               <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">
                 <input matInput formControlName="postalCodeBilling" placeholder="Enter postal code" />
-                <mat-error *ngIf="postalCodeBilling?.hasError('postCodeValid')">Postal code is not valid.</mat-error>
+                <mat-error *ngIf="postalCodeBillingValidError">Postal code is not valid.</mat-error>
               </mat-form-field>
-              <mat-checkbox appearance="outline" class="example-margin" formControlName="isBothAddress"
-                >Set as shipping address too</mat-checkbox
-              >
+
+              <mat-checkbox appearance="outline" class="example-margin" formControlName="isBothAddress">
+                Set as shipping address too
+              </mat-checkbox>
             </div>
-            @if (!registerForm.get('isBothAddress')?.value) {
+
+            @if (!isBothAddressValue) {
               <div>
                 <p class="login-form__label">Enter shipping Address</p>
                 <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">
@@ -98,15 +110,18 @@
                     }
                   </mat-select>
                 </mat-form-field>
+
                 <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">
                   <input matInput formControlName="cityShipping" placeholder="Enter city" />
                 </mat-form-field>
+
                 <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">
                   <input matInput formControlName="streetShipping" placeholder="Enter street" />
                 </mat-form-field>
+
                 <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">
                   <input matInput formControlName="postalCodeShipping" placeholder="Enter postal code" />
-                  <mat-error *ngIf="postalCodeShipping?.hasError('postCodeValid')">Postal code is not valid.</mat-error>
+                  <mat-error *ngIf="postalCodeShippingValidError">Postal code is not valid.</mat-error>
                 </mat-form-field>
               </div>
             }
@@ -117,8 +132,8 @@
       <p class="login-form__label">Enter Your Email</p>
       <mat-form-field appearance="outline" class="login-form__field login-form__field--full-width">
         <input matInput formControlName="email" placeholder="Enter email" />
-        <mat-error *ngIf="email?.hasError('required')">Email is required.</mat-error>
-        <mat-error *ngIf="email?.hasError('email') || email?.hasError('pattern')">Invalid email format.</mat-error>
+        <mat-error *ngIf="emailRequiredError">Email is required.</mat-error>
+        <mat-error *ngIf="emailFormatError">Invalid email format.</mat-error>
       </mat-form-field>
 
       <p class="login-form__label">Enter Your Password</p>
@@ -137,11 +152,9 @@
           type="button">
           <mat-icon>{{ hidePassword ? 'visibility_off' : 'visibility' }}</mat-icon>
         </button>
-        <mat-error *ngIf="password?.hasError('required')">Password is required.</mat-error>
-        <mat-error *ngIf="password?.hasError('minlength')">Password must be at least 8 characters.</mat-error>
-        <mat-error *ngIf="password?.hasError('pattern')"
-          >Must include upper, lower, digit, and no whitespace.</mat-error
-        >
+        <mat-error *ngIf="passwordRequiredError">Password is required.</mat-error>
+        <mat-error *ngIf="passwordMinLengthError">Password must be at least 8 characters.</mat-error>
+        <mat-error *ngIf="passwordPatternError">Must include upper, lower, digit, and no whitespace.</mat-error>
       </mat-form-field>
 
       <button mat-stroked-button type="submit" [disabled]="registerForm.invalid" class="login-form__login-button">

--- a/src/pages/register/register.component.scss
+++ b/src/pages/register/register.component.scss
@@ -30,7 +30,9 @@
 .mat-mdc-outlined-button:not(:disabled) {
   color: #fff;
 }
-
+mat-error {
+  margin-top: 0;
+}
 .login-form__register-link {
   text-decoration: underline;
   color: #282828;
@@ -118,10 +120,13 @@
     height: 200px;
   }
 }
-
+mat-form-field {
+  margin-bottom: 6px;
+}
 mat-error {
-  font-size: 0.85rem;
+  display: inline;
+  font-size: 0.78rem;
   color: #e53935;
   font-weight: 500;
-  margin-top: 4px;
+  line-height: 0.2;
 }

--- a/src/pages/register/register.component.ts
+++ b/src/pages/register/register.component.ts
@@ -73,7 +73,7 @@ export class RegisterComponent implements OnInit {
   ) {
     this.registerForm = this.fb.group({
       firstName: ['', [Validators.required, Validators.pattern(/^\p{L}*$/u)]],
-      lastName: ['', [Validators.required, Validators.minLength(2)]],
+      lastName: ['', [Validators.required, Validators.pattern(/^\p{L}*$/u)]],
       dateOfBirth: ['', [Validators.required, minAgeValidator(this.countYears)]],
       country: ['', [Validators.required]],
       countryBilling: [''],

--- a/src/pages/register/register.component.ts
+++ b/src/pages/register/register.component.ts
@@ -35,6 +35,8 @@ interface CustomerData {
   defaultBillingAddress?: number;
 }
 
+const MIN_YEARS_TO_LOGIN = 13;
+const MIN_LENGTH_VALIDATE_PASSWORD = 8;
 @Component({
   selector: 'app-register',
   imports: [
@@ -59,7 +61,7 @@ export class RegisterComponent implements OnInit {
     { code: 'BY', name: 'Belarus' },
     { code: 'US', name: 'United States' },
   ];
-  private countYears = 13;
+  private countYears = MIN_YEARS_TO_LOGIN;
   public hidePassword = true;
   public registerForm: FormGroup;
   public isValidForm = false;
@@ -94,14 +96,14 @@ export class RegisterComponent implements OnInit {
         '',
         [
           Validators.required,
-          Validators.minLength(8),
+          Validators.minLength(MIN_LENGTH_VALIDATE_PASSWORD),
           Validators.pattern(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*])?[A-Za-z\d!@#$%^&*]{8,}$/),
           Validators.pattern(/^\S+$/),
         ],
       ],
     });
   }
-  ngOnInit(): void {
+  public ngOnInit(): void {
     this.registerForm.valueChanges
       .pipe(
         distinctUntilChanged((prev, curr) => {
@@ -118,7 +120,7 @@ export class RegisterComponent implements OnInit {
         this.registerForm.get('postalCodeShipping')?.updateValueAndValidity();
       });
   }
-  onSubmit(): void {
+  public onSubmit(): void {
     const formData = this.registerForm.value;
     const customerData: CustomerData = {
       email: formData.email,
@@ -213,37 +215,122 @@ export class RegisterComponent implements OnInit {
     });
   }
 
-  get firstName(): AbstractControl | null {
+  public get firstNameRequiredError(): boolean {
+    return this.registerForm.get('firstName')?.hasError('required') ?? false;
+  }
+
+  public get firstNamePatternError(): boolean {
+    return this.registerForm.get('firstName')?.hasError('pattern') ?? false;
+  }
+
+  public get lastNameRequiredError(): boolean {
+    return this.registerForm.get('lastName')?.hasError('required') ?? false;
+  }
+
+  public get lastNamePatternError(): boolean {
+    return this.registerForm.get('lastName')?.hasError('pattern') ?? false;
+  }
+
+  public get dateOfBirthRequiredError(): boolean {
+    return this.registerForm.get('dateOfBirth')?.hasError('required') ?? false;
+  }
+
+  public get dateOfBirthMinAgeError(): boolean {
+    return this.registerForm.get('dateOfBirth')?.hasError('minAge') ?? false;
+  }
+
+  public get countryRequiredError(): boolean {
+    return this.registerForm.get('country')?.hasError('required') ?? false;
+  }
+
+  public get cityRequiredError(): boolean {
+    return this.registerForm.get('city')?.hasError('required') ?? false;
+  }
+
+  public get cityPatternError(): boolean {
+    return this.registerForm.get('city')?.hasError('pattern') ?? false;
+  }
+
+  public get streetRequiredError(): boolean {
+    return this.registerForm.get('street')?.hasError('required') ?? false;
+  }
+  public get postalCodeRequiredError(): boolean {
+    return this.registerForm.get('postalCode')?.hasError('required') ?? false;
+  }
+
+  public get postalCodeValidError(): boolean {
+    return this.registerForm.get('postalCode')?.hasError('postCodeValid') ?? false;
+  }
+
+  public get postalCodeBillingValidError(): boolean {
+    return this.registerForm.get('postalCodeBilling')?.hasError('postCodeValid') ?? false;
+  }
+
+  public get postalCodeShippingValidError(): boolean {
+    return this.registerForm.get('postalCodeShipping')?.hasError('postCodeValid') ?? false;
+  }
+
+  public get emailRequiredError(): boolean {
+    return this.registerForm.get('email')?.hasError('required') ?? false;
+  }
+
+  public get emailFormatError(): boolean {
+    return (
+      (this.registerForm.get('email')?.hasError('email') || this.registerForm.get('email')?.hasError('pattern')) ??
+      false
+    );
+  }
+
+  public get passwordRequiredError(): boolean {
+    return this.registerForm.get('password')?.hasError('required') ?? false;
+  }
+
+  public get passwordMinLengthError(): boolean {
+    return this.registerForm.get('password')?.hasError('minlength') ?? false;
+  }
+
+  public get passwordPatternError(): boolean {
+    return this.registerForm.get('password')?.hasError('pattern') ?? false;
+  }
+
+  public get isDefaultAddressValue(): boolean {
+    return this.registerForm.get('isDefaultAddress')?.value ?? false;
+  }
+
+  public get isBothAddressValue(): boolean {
+    return this.registerForm.get('isBothAddress')?.value ?? false;
+  }
+  public get firstName(): AbstractControl | null {
     return this.registerForm.get('firstName');
   }
-  get lastName(): AbstractControl | null {
+  public get lastName(): AbstractControl | null {
     return this.registerForm.get('lastName');
   }
-  get dateOfBirth(): AbstractControl | null {
+  public get dateOfBirth(): AbstractControl | null {
     return this.registerForm.get('dateOfBirth');
   }
-  get country(): AbstractControl | null {
+  public get country(): AbstractControl | null {
     return this.registerForm.get('country');
   }
-  get city(): AbstractControl | null {
+  public get city(): AbstractControl | null {
     return this.registerForm.get('city');
   }
-  get street(): AbstractControl | null {
+  public get street(): AbstractControl | null {
     return this.registerForm.get('street');
   }
-  get email(): AbstractControl | null {
+  public get email(): AbstractControl | null {
     return this.registerForm.get('email');
   }
-  get password(): AbstractControl | null {
+  public get password(): AbstractControl | null {
     return this.registerForm.get('password');
   }
-  get postalCode(): AbstractControl | null {
+  public get postalCode(): AbstractControl | null {
     return this.registerForm.get('postalCode');
   }
-  get postalCodeBilling(): AbstractControl | null {
+  public get postalCodeBilling(): AbstractControl | null {
     return this.registerForm.get('postalCodeBilling');
   }
-  get postalCodeShipping(): AbstractControl | null {
+  public get postalCodeShipping(): AbstractControl | null {
     return this.registerForm.get('postalCodeShipping');
   }
 }

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -16,7 +16,7 @@ export class ApiService {
 
   constructor(private http: HttpClient) {}
 
-  getClientCredentialsToken(scope: string, path?: string): Observable<TokenResponse> {
+  public getClientCredentialsToken(scope: string, path?: string): Observable<TokenResponse> {
     const body = new URLSearchParams();
     body.append('grant_type', 'client_credentials');
     body.append('scope', scope);
@@ -25,12 +25,12 @@ export class ApiService {
     });
   }
 
-  getAnonymousToken(): Observable<TokenResponse> {
+  public getAnonymousToken(): Observable<TokenResponse> {
     const scope = `manage_project:${environment.projectKey}`;
     return this.getClientCredentialsToken(scope, this.anonymousTokenUrl);
   }
 
-  getCustomerToken(credentials: { email: string; password: string }): Observable<TokenResponse> {
+  public getCustomerToken(credentials: { email: string; password: string }): Observable<TokenResponse> {
     const body = new URLSearchParams();
     body.append('grant_type', 'password');
     body.append('username', credentials.email);
@@ -41,7 +41,7 @@ export class ApiService {
     });
   }
 
-  refreshToken(refreshToken: string): Observable<TokenResponse> {
+  public refreshToken(refreshToken: string): Observable<TokenResponse> {
     const body = new URLSearchParams();
     body.append('grant_type', 'refresh_token');
     body.append('refresh_token', refreshToken);
@@ -50,7 +50,7 @@ export class ApiService {
     });
   }
 
-  introspectToken(token: string): Observable<Introspect> {
+  public introspectToken(token: string): Observable<Introspect> {
     const body = new URLSearchParams();
     body.append('token', token);
     return this.http.post<Introspect>(this.introspectUrl, body, {
@@ -58,7 +58,7 @@ export class ApiService {
     });
   }
 
-  createCustomer(customerData: CustomerProps): Observable<Customer> {
+  public createCustomer(customerData: CustomerProps): Observable<Customer> {
     console.log(customerData);
 
     return this.http.post<Customer>(this.customersUrl, customerData, {
@@ -66,7 +66,7 @@ export class ApiService {
     });
   }
 
-  getProducts(): Observable<ProductResponse> {
+  public getProducts(): Observable<ProductResponse> {
     return this.http.get<ProductResponse>(this.productsUrl);
   }
 

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -15,7 +15,7 @@ export class AuthService {
     private router: Router
   ) {}
 
-  login(email: string, password: string): Observable<TokenResponse> {
+  public login(email: string, password: string): Observable<TokenResponse> {
     return this.api.getCustomerToken({ email, password }).pipe(
       tap(response => {
         console.log('Login successful, saving token and redirecting');
@@ -29,7 +29,7 @@ export class AuthService {
     );
   }
 
-  checkLoginStatus(): boolean {
+  public checkLoginStatus(): boolean {
     try {
       const tokens = this.store.getTokens();
       return !!tokens && !!tokens.accessToken;
@@ -39,7 +39,7 @@ export class AuthService {
     }
   }
 
-  logout(): void {
+  public logout(): void {
     console.log('Logging out and redirecting to login page');
     this.store.clearTokens(); // Make sure we have this method
     this.router.navigate(['/login']);
@@ -49,7 +49,7 @@ export class AuthService {
    * Redirect authenticated users away from login page
    * @returns boolean indicating if redirect was performed
    */
-  redirectIfLoggedIn(): boolean {
+  public redirectIfLoggedIn(): boolean {
     if (this.checkLoginStatus()) {
       console.log('User is logged in, redirecting to main');
       this.router.navigate(['/main']);

--- a/src/services/storage.service.ts
+++ b/src/services/storage.service.ts
@@ -8,15 +8,15 @@ interface TokenStore {
 @Injectable({ providedIn: 'root' })
 export class StorageService {
   private readonly tokens = 'tokens_commerce_technik';
-  setTokens(tokens: Partial<TokenStore>) {
+  public setTokens(tokens: Partial<TokenStore>): void {
     const listToken = { accessToken: '', refreshToken: '', ...tokens };
     localStorage.setItem(this.tokens, JSON.stringify(listToken));
   }
-  getTokens(): TokenStore {
+  public getTokens(): TokenStore {
     const tokens = JSON.parse(localStorage.getItem(this.tokens) || '');
     return tokens || { accessToken: '', refreshToken: '' };
   }
-  clearTokens(): void {
+  public clearTokens(): void {
     try {
       localStorage.removeItem(this.tokens);
       console.log('Tokens cleared from storage');

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,14 +1,26 @@
 import { AbstractControl, ValidatorFn } from '@angular/forms';
 import postalCodes from 'postal-codes-js';
 
+const COUNT_NUMBER = 5;
+const COUNT_DAYS_IN_YEAR = 365;
+const COUNT_HOURS_IN_DAYS = 24;
+const COUNT_MINUTES_IN_HOURS = 60;
+const COUNT_SECONDS_IN_MINUTES = 60;
+const COUNT_MS_IN_SECOND = 1000;
 export function getRandomId(): string {
-  return Date.now().toString() + Math.random().toFixed(5);
+  return Date.now().toString() + Math.random().toFixed(COUNT_NUMBER);
 }
 
 export function minAgeValidator(minAge: number): ValidatorFn {
   function howOldAreYou(currentValue: number, value: string): boolean {
     const date = new Date(value);
-    const years = currentValue * 365 * 24 * 60 * 60 * 1000;
+    const years =
+      currentValue *
+      COUNT_DAYS_IN_YEAR *
+      COUNT_HOURS_IN_DAYS *
+      COUNT_MINUTES_IN_HOURS *
+      COUNT_SECONDS_IN_MINUTES *
+      COUNT_MS_IN_SECOND;
     const different = Date.now() - date.getTime();
     return different > years;
   }


### PR DESCRIPTION
## ECOMM-39

## Description
- Class Fields and Methods Must Have Access Modifiers and Return Types
- Disallow Commented-Out Code
- Disallow Magic Numbers and Strings
- Disallow Unused Imports and Variables
- Template Linting

## What Has Been Done (Checklist)
### Used:
 - [x] Enforce explicit public, private, or protected modifiers.
 - [x] Require return types for all methods, even when inferred.
 - [x] Commented-out blocks of code must be removed.
 - [x] Use named constants or enums instead of hard-coded numbers or strings.
 - [x] Clean up any unused imports or variables to reduce noise and prevent potential bugs.
 - [x] Use Angular Template Linter to enforce best practices in HTML (e.g., accessibility, consistent naming, no unused variables in templates).






